### PR TITLE
Adding Skript-MC provider

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from providers import (
     SkUnityDocumentationProvider,
     SkriptLangDocumentationProvider,
     CombinedDocumentationProvider,
+    SkriptMcDocumentationProvider,
 )
 from views import SearchView
 
@@ -27,6 +28,7 @@ providers = {
     "skriptlang": SkriptLangDocumentationProvider(),
     "skripthub": SkriptHubDocumentationProvider(os.environ["SKRIPT_SKRIPTHUB_TOKEN"]),
     "skunity": SkUnityDocumentationProvider(os.environ["SKRIPT_SKUNITY_KEY"]),
+    "skriptmc": SkriptMcDocumentationProvider(os.environ["SKRIPT_SKRIPTMC_KEY"])
 }
 
 database_path = Path(os.environ["SKRIPT_DATA_PATH"]) / "data.json"


### PR DESCRIPTION
Based on the idea of @Pikachu920, this PR adds the https://skript-mc.fr provider, a French forum from the Skript community offering documentation translated into French.

This PR adds a dependency: Levenshtein. The provider's syntaxes are loaded automatically when the bot is started, and no further requests will be made. Only the distance will be used, with search support in English and French.

Don't hesitate to make any comments you may have on codestyle and other topics!